### PR TITLE
Use CSS outline instead of border for hover effect on 'delete' button, s...

### DIFF
--- a/css/ui.css
+++ b/css/ui.css
@@ -459,7 +459,7 @@ body {
   display: block;
 }
 .fileListItemDelete:hover {
-  border: solid 1px;
+  outline: solid 1px;
 }
 .busyCover {
   position: absolute;


### PR DESCRIPTION
...ince border affects layout & moves the button.

Right now, if you hover the "Delete" button (red "x") on cleopatra's profile listing, the button moves when its border appears. That's because CSS borders take up space & influence layout.

We should use a CSS outline instead, which does not take up space or influence layout.  (Alternately, we could have a border be there all along but just start out transparent; but this is simpler.)
