### PR TITLE
Fix chooser panel backdrop.

### DIFF
--- a/css/ui.css
+++ b/css/ui.css
@@ -700,16 +700,15 @@ iframe {
   margin: auto;
   background: none repeat scroll 0% 0% rgb(221, 221, 221);
   box-shadow: 0px 0px 0px 1px rgba(0, 0, 0, 0.1),
-              0px 5px 10px rgba(0, 0, 0, 0.4)
+              0px 5px 10px rgba(0, 0, 0, 0.4),
               0px 0px 0px 1000px rgba(0, 0, 0, 0.3);
   display: flex;
   flex-direction: column;
-  transition: opacity 0.5s ease-in-out, transform 0.5s ease-in-out;
+  transition: opacity 0.5s ease-in-out;
 }
 
 .chooserPanel:not(.appear) {
   opacity: 0;
-  transform: translateY(100px);
 }
 
 .chooserPanel > h3 {


### PR DESCRIPTION
I dropped a comma.

This change also removes the transform animation because it looked bad, and because the giant box-shadow backdrop trick would have required a huge layer for the animation to be OMTA-able.