### PR TITLE
Correct usage text for uniformity

### DIFF
--- a/js/waterfall.js
+++ b/js/waterfall.js
@@ -264,7 +264,7 @@ Waterfall.createFramePositionView = function(framePositions) {
                "setting the preference layers.uniformity-info to true and by " +
                "profiling the compositor thread. To profile the compositor thread, " +
                "Use the command './profile.sh start -p b2g -t Compositor'. To get touch data, " +
-               "also profile the 'GeckoMain' thread. e.g. ./profile.sh -p b2g -t Compositor,GeckoMain'";
+               "also profile the 'GeckoMain' thread. e.g. './profile.sh start -p b2g -t Compositor,GeckoMain'";
     container.innerHTML = text;
   }
 


### PR DESCRIPTION
BTW, I tried using `./profile.sh start -p b2g -t Compositor` and `./profile.sh start -p b2g -t Compositor,GeckoMain`, and I can get touch event only from the first one. Maybe there's some change inside B2G?