### PR TITLE
Ignore instead of throw if filter is invalid

### DIFF
--- a/js/cleopatra.js
+++ b/js/cleopatra.js
@@ -285,8 +285,11 @@
         gReportID = queryData.report;
       }
       if (queryData.filter) {
-        var filterChain = JSON.parse(queryData.filter);
-        gSampleFilters = filterChain;
+        try {
+          var filterChain = JSON.parse(queryData.filter);
+          gSampleFilters = filterChain;
+        } catch (e) {
+        }
       }
       if (queryData.select) {
         var parts = queryData.select.split(',');


### PR DESCRIPTION
Sometimes the filter could be incorrectly cut off, e.g. by Bugzilla. In that case, don't give up loading, just treat it as no filter ever exists.

See [Bug 1220502 comment 33](https://bugzilla.mozilla.org/show_bug.cgi?id=1220502#c33) for instance.